### PR TITLE
Update baseline to skip ogre conflicts (#9331)

### DIFF
--- a/scripts/ci.baseline.txt
+++ b/scripts/ci.baseline.txt
@@ -1153,6 +1153,15 @@ ogdf:x64-uwp            = skip
 ogdf:x64-windows        = skip
 ogdf:x64-windows-static = skip
 ogdf:x86-windows        = skip
+# Conflicts with ogre
+ogre-next:arm64-windows      = skip
+ogre-next:arm-uwp            = skip
+ogre-next:x64-osx            = skip
+ogre-next:x64-linux          = skip
+ogre-next:x64-uwp            = skip
+ogre-next:x64-windows        = skip
+ogre-next:x64-windows-static = skip
+ogre-next:x86-windows        = skip
 ois:arm64-windows=fail
 ois:arm-uwp=fail
 ois:x64-uwp=fail


### PR DESCRIPTION
* update baseline

* Replace ogre with ogre-next in baseline results

**Describe the pull request**

- What does your PR fix? Fixes issue #

- Which triplets are supported/not supported? Have you updated the CI baseline?

- Does your PR follow the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)?
