### PR TITLE
[python3] Fix python3:x64-linux builds (#18405)

### DIFF
--- a/ports/python3/portfile.cmake
+++ b/ports/python3/portfile.cmake
@@ -172,7 +172,6 @@ else()
     )
     vcpkg_install_make(ADD_BIN_TO_PATH INSTALL_TARGET altinstall)
 
-    file(COPY "${CURRENT_PACKAGES_DIR}/bin/" DESTINATION "${CURRENT_PACKAGES_DIR}/tools/${PORT}/bin")
     file(COPY "${CURRENT_PACKAGES_DIR}/tools/${PORT}/bin/" DESTINATION "${CURRENT_PACKAGES_DIR}/tools/${PORT}")
 
     # Makefiles, c files, __pycache__, and other junk.

--- a/ports/python3/vcpkg.json
+++ b/ports/python3/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "python3",
   "version-string": "3.9.5",
+  "port-version": 1,
   "description": "The Python programming language",
   "homepage": "https://github.com/python/cpython",
   "supports": "!(arm | uwp)",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -5046,7 +5046,7 @@
     },
     "python3": {
       "baseline": "3.9.5",
-      "port-version": 0
+      "port-version": 1
     },
     "qca": {
       "baseline": "2.3.1",

--- a/versions/p-/python3.json
+++ b/versions/p-/python3.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "0c58aaaa7b980102912bbd8b13ba3ac227b37bd4",
+      "version-string": "3.9.5",
+      "port-version": 1
+    },
+    {
       "git-tree": "16ae1dd8eb0498d1357af3155c565035ba9a3f39",
       "version-string": "3.9.5",
       "port-version": 0


### PR DESCRIPTION
* Fix build

* Update vcpkg.json

* Fix build

Co-authored-by: Ankur Verma <ankurv@microsoft.com>
Co-authored-by: Ankur Verma <ankurv@nuc.hogwarts>

**Describe the pull request**

- #### What does your PR fix?  
  Fixes #...

- #### Which triplets are supported/not supported? Have you updated the [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt)?  
  <all / linux, windows, ...>, <Yes/No>

- #### Does your PR follow the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)?  
  `Your answer`

- #### If you have added/updated a port: Have you run `./vcpkg x-add-version --all` and committed the result?  
  <Yes / I am still working on this PR>

**If you are still working on the PR, open it as a Draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/**
