### PR TITLE
[vcpkg baseline][tensorflow] Skip osx check in baseline (#18812)

### DIFF
--- a/scripts/ci.baseline.txt
+++ b/scripts/ci.baseline.txt
@@ -1794,4 +1794,5 @@ dimcli:x64-windows-static=fail
 cppgraphqlgen:x64-osx=fail
 
 # Changes in Python have broken tensorflow on our osx hardware
+tensorflow:x64-osx=fail
 tensorflow-cc:x64-osx=fail


### PR DESCRIPTION
* [vcpkg baseline][tensorflow] Skip osx check in baseline

* move item under tensorflow:x64-osx

**Describe the pull request**

- #### What does your PR fix?  
  Fixes #...

- #### Which triplets are supported/not supported? Have you updated the [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt)?  
  <all / linux, windows, ...>, <Yes/No>

- #### Does your PR follow the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)?  
  `Your answer`

- #### If you have added/updated a port: Have you run `./vcpkg x-add-version --all` and committed the result?  
  <Yes / I am still working on this PR>

**If you are still working on the PR, open it as a Draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/**
