### PR TITLE
[gettext] Add gettext cmake wrapper (#18159)

### DIFF
--- a/ports/gettext/Makefile
+++ b/ports/gettext/Makefile
@@ -1,0 +1,65 @@
+all: build-gettext-runtime-intl build-gettext-runtime-po build-gettext-runtime-src
+all: build-gettext-tools build-gettext-tools-gnulib build-gettext-tools-its build-gettext-tools-m4 build-gettext-tools-misc build-gettext-tools-po build-gettext-tools-projects build-gettext-tools-styles
+all: build-libtextstyle
+
+install: install-gettext-runtime-intl install-gettext-runtime-po install-gettext-runtime-src
+install: install-gettext-tools install-gettext-tools-gnulib install-gettext-tools-its install-gettext-tools-m4 install-gettext-tools-misc install-gettext-tools-po install-gettext-tools-projects install-gettext-tools-styles
+install: install-libtextstyle
+
+build-gettext-runtime-gnulib: build-gettext-runtime-intl
+	$(MAKE) -C gettext-runtime/gnulib-lib all
+build-gettext-runtime-intl:
+	$(MAKE) -C gettext-runtime/intl all
+build-gettext-runtime-po:
+	$(MAKE) -C gettext-runtime/po all
+build-gettext-runtime-src: build-gettext-runtime-intl build-gettext-runtime-gnulib
+	$(MAKE) -C gettext-runtime/src all
+build-gettext-tools: build-gettext-runtime-intl build-libtextstyle build-gettext-tools-gnulib build-gettext-tools-intl build-gettext-tools-libgrep build-gnulib-local
+	$(MAKE) -C gettext-tools/src all
+build-gettext-tools-gnulib: build-gettext-tools-intl
+	$(MAKE) -C gettext-tools/gnulib-lib all
+build-gettext-tools-libgrep: build-gettext-tools-gnulib
+	$(MAKE) -C gettext-tools/libgrep all
+build-gettext-tools-intl:
+	$(MAKE) -C gettext-tools/intl all
+build-gettext-tools-its:
+	$(MAKE) -C gettext-tools/its all
+build-gettext-tools-m4:
+	$(MAKE) -C gettext-tools/m4 all
+build-gettext-tools-misc:
+	$(MAKE) -C gettext-tools/misc all
+build-gettext-tools-po:
+	$(MAKE) -C gettext-tools/po all
+build-gettext-tools-projects:
+	$(MAKE) -C gettext-tools/projects all
+build-gettext-tools-styles:
+	$(MAKE) -C gettext-tools/styles all
+build-gnulib-local:
+	$(MAKE) -C gnulib-local all
+build-libtextstyle:
+	$(MAKE) -C libtextstyle/lib all
+
+install-gettext-runtime-intl:
+	$(MAKE) -C gettext-runtime/intl install
+install-gettext-runtime-po:
+	$(MAKE) -C gettext-runtime/po install
+install-gettext-runtime-src:
+	$(MAKE) -C gettext-runtime/src install
+install-gettext-tools:
+	$(MAKE) -C gettext-tools/src install
+install-gettext-tools-gnulib:
+	$(MAKE) -C gettext-tools/gnulib-lib install
+install-gettext-tools-its:
+	$(MAKE) -C gettext-tools/its install
+install-gettext-tools-m4:
+	$(MAKE) -C gettext-tools/m4 install
+install-gettext-tools-misc:
+	$(MAKE) -C gettext-tools/misc install
+install-gettext-tools-po:
+	$(MAKE) -C gettext-tools/po install
+install-gettext-tools-projects:
+	$(MAKE) -C gettext-tools/projects install
+install-gettext-tools-styles:
+	$(MAKE) -C gettext-tools/styles install
+install-libtextstyle:
+	$(MAKE) -C libtextstyle/lib install

--- a/ports/gettext/vcpkg-port-config.cmake
+++ b/ports/gettext/vcpkg-port-config.cmake
@@ -1,0 +1,6 @@
+get_filename_component(gettext_tools_dir "${CMAKE_CURRENT_LIST_DIR}/../../tools/gettext/bin" ABSOLUTE)
+if(CMAKE_HOST_WIN32)
+    set(ENV{PATH} "$ENV{PATH};${gettext_tools_dir}")
+else()
+    set(ENV{PATH} "$ENV{PATH}:${gettext_tools_dir}")
+endif()

--- a/ports/gettext/vcpkg.json
+++ b/ports/gettext/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "gettext",
   "version": "0.21",
-  "port-version": 3,
+  "port-version": 4,
   "description": "The GNU gettext utilities are a set of tools that provides a framework to help other GNU packages produce multi-lingual messages. Provides libintl.",
   "homepage": "https://www.gnu.org/software/gettext/",
   "dependencies": [

--- a/ports/kf5i18n/portfile.cmake
+++ b/ports/kf5i18n/portfile.cmake
@@ -10,27 +10,6 @@ vcpkg_from_github(
     PATCHES ${PATCHES}
 )
 
-if(CMAKE_HOST_WIN32)
-    vcpkg_acquire_msys(MSYS_ROOT NO_DEFAULT_PACKAGES DIRECT_PACKAGES
-        "https://repo.msys2.org/mingw/i686/mingw-w64-i686-gettext-0.19.8.1-9-any.pkg.tar.zst"
-        c632877544183def8b19659421c5511b87f8339596e1606bd47608277a0bf427d370aba1732915c2832c91f6d525261623401f145b951ff3015f79ac54179c19
-        "https://repo.msys2.org/mingw/i686/mingw-w64-i686-libiconv-1.16-1-any.pkg.tar.xz"
-        ba236e1efc990cb91d459f938be6ca6fc2211be95e888d73f8de301bce55d586f9d2b6be55dacb975ec1afa7952b510906284eff70210238919e341dffbdbeb8
-        "https://repo.msys2.org/mingw/i686/mingw-w64-i686-gcc-libs-10.2.0-1-any.pkg.tar.zst"
-        113d8b3b155ea537be8b99688d454f781d70c67c810c2643bc02b83b332d99bfbf3a7fcada6b927fda67ef02cf968d4fdf930466c5909c4338bda64f1f3f483e
-        "https://repo.msys2.org/mingw/i686/mingw-w64-i686-libwinpthread-git-8.0.0.5906.c9a21571-1-any.pkg.tar.zst"
-        2c3d9e6b2eee6a4c16fd69ddfadb6e2dc7f31156627d85845c523ac85e5c585d4cfa978659b1fe2ec823d44ef57bc2b92a6127618ff1a8d7505458b794f3f01c
-        "https://repo.msys2.org/mingw/i686/mingw-w64-i686-mpc-1.1.0-1-any.pkg.tar.xz"
-        d236b815ec3cf569d24d96a386eca9f69a2b1e8af18e96c3f1e5a4d68a3598d32768c7fb3c92207ecffe531259822c1a421350949f2ffabd8ee813654f1af864
-        "https://repo.msys2.org/mingw/i686/mingw-w64-i686-mpfr-4.1.0-2-any.pkg.tar.zst"
-        caac5cb73395082b479597a73c7398bf83009dbc0051755ef15157dc34996e156d4ed7881ef703f9e92861cfcad000888c4c32e4bf38b2596c415a19aafcf893
-        "https://repo.msys2.org/mingw/i686/mingw-w64-i686-gmp-6.2.0-1-any.pkg.tar.xz"
-        37747f3f373ebff1a493f5dec099f8cd6d5abdc2254d9cd68a103ad7ba44a81a9a97ccaba76eaee427b4d67b2becb655ee2c379c2e563c8051b6708431e3c588
-    )
-    set(GETTEXT_PATH ${MSYS_ROOT}/mingw32/bin)
-    vcpkg_add_to_path(${GETTEXT_PATH})
-endif()
-
 vcpkg_find_acquire_program(PYTHON3)
 
 vcpkg_configure_cmake(

--- a/ports/kf5i18n/vcpkg.json
+++ b/ports/kf5i18n/vcpkg.json
@@ -1,12 +1,19 @@
 {
   "name": "kf5i18n",
   "version": "5.81.0",
-  "port-version": 1,
+  "port-version": 2,
   "description": "Advanced internationalization framework",
   "homepage": "https://api.kde.org/frameworks/ki18n/html/index.html",
   "dependencies": [
     "ecm",
     "gettext",
+    {
+      "name": "gettext",
+      "host": true,
+      "features": [
+        "tools"
+      ]
+    },
     "qt5-declarative",
     "qt5-tools"
   ]

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -2266,7 +2266,7 @@
     },
     "gettext": {
       "baseline": "0.21",
-      "port-version": 3
+      "port-version": 4
     },
     "gettimeofday": {
       "baseline": "2017-10-14-3",
@@ -2902,7 +2902,7 @@
     },
     "kf5i18n": {
       "baseline": "5.81.0",
-      "port-version": 1
+      "port-version": 2
     },
     "kf5itemmodels": {
       "baseline": "5.81.0",

--- a/versions/g-/gettext.json
+++ b/versions/g-/gettext.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "b6cde01ab4095a258993eaf85eb31c1e845c64a6",
+      "version": "0.21",
+      "port-version": 4
+    },
+    {
       "git-tree": "33c7af8451faeef94c8a06cb41b71dce144d6fba",
       "version": "0.21",
       "port-version": 3

--- a/versions/k-/kf5i18n.json
+++ b/versions/k-/kf5i18n.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "98407edcc42c1bb91f4a1fe218f30c3a2757a530",
+      "version": "5.81.0",
+      "port-version": 2
+    },
+    {
       "git-tree": "a749b5eb069f5e7a8c84a65746ca7579d2e85af5",
       "version": "5.81.0",
       "port-version": 1


### PR DESCRIPTION
* Add gettext cmake wrapper

* x-add-version

* Make kf5i18n use gettext[tools]:host

* x-add-version

* Revise wrapper source names

* Update git-tree

* Provide host tools via port config, not wrapper

* Enable tools on linux

* Fix linux libintl.h hint

* Update git-tree

* Update git-tree

* Revise vcpkg port config

* Revise linux libintl.h message

* Revise cmake style

* Build only release variant of tools

* Cache configuration for faster build

* Update git-tree

* Fix typo

* Revise options

* Add top-level Makefile for tools

* Remove non-libintl libs and includes

* Update git-tree

* Update port-version

* x-add-version

* [gettext] Address PR comments

Co-authored-by: Robert Schumacher <roschuma@microsoft.com>

**Describe the pull request**

- #### What does your PR fix?  
  Fixes #...

- #### Which triplets are supported/not supported? Have you updated the [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt)?  
  <all / linux, windows, ...>, <Yes/No>

- #### Does your PR follow the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)?  
  `Your answer`

- #### If you have added/updated a port: Have you run `./vcpkg x-add-version --all` and committed the result?  
  <Yes / I am still working on this PR>

**If you are still working on the PR, open it as a Draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/**
